### PR TITLE
feat: add claude api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ $ export ANTHROPIC_API_KEY=sk-ant-your-key
 $ pnpm generate --claude --username foo --milestone 1.20.0 --token github_token_foo_bar
 ```
 
+- You can also specify a model with `--model` (defaults to `claude-sonnet-4-20250514`). See [available models](https://docs.anthropic.com/en/docs/about-claude/models).
+
+```
+$ export ANTHROPIC_API_KEY=sk-ant-your-key
+$ pnpm generate --claude --username foo --milestone 1.20.0 --model claude-sonnet-4-20250514 --token github_token_foo_bar
+```
+
 4. Generate release notes using Claude via Vertex AI
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,27 +1,48 @@
 # Podman Desktop tool-release-notes
+
 Tool to automate the creation of Release Notes for Podman Desktop
 
 ## Usage
+
 - Generate release notes `pnpm generate`
 - Test `pnpm test`
 
 ### Examples
 
 1. Generate release notes using AI Lab service
+
 ```
 $ export GITHUB_TOKEN=github_token_foo_bar
 $ pnpm generate --username foo --milestone 1.20.0 --port 12345
 ```
 
 2. Generate release notes using ollama
+
 - For this you need to have running ollama model in this example e.g. gemma3:27b
+
 ```
 $ pnpm generate --ollama --username foo --milestone 1.20.0 --model gemma3:27b --token github_token_foo_bar
 ```
 
-3. Generate release notes without generating feature highlights
+3. Generate release notes using Claude (Anthropic API)
+
+```
+$ export ANTHROPIC_API_KEY=sk-ant-your-key
+$ pnpm generate --claude --username foo --milestone 1.20.0 --token github_token_foo_bar
+```
+
+4. Generate release notes using Claude via Vertex AI
+
+```
+$ export ANTHROPIC_VERTEX_PROJECT_ID=my-gcp-project
+$ export CLOUD_ML_REGION=us-east5
+$ pnpm generate --claude --username foo --milestone 1.20.0 --token github_token_foo_bar
+```
+
+5. Generate release notes without generating feature highlights
+
 - Don't provide `model` and `port` argument
+
 ```
 $ pnpm generate --username foo --milestone 1.20.0 --token github_token_foo_bar
 ```
-

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "packageManager": "pnpm@10.7.0",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
+    "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@eslint/compat": "^1.3.1",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.78.0
+        version: 0.78.0
+      '@anthropic-ai/vertex-sdk':
+        specifier: ^0.14.4
+        version: 0.14.4
       '@eslint/compat':
         specifier: ^1.3.1
         version: 1.3.1(eslint@9.31.0(jiti@2.6.0))
@@ -121,6 +127,18 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@anthropic-ai/sdk@0.78.0':
+    resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@anthropic-ai/vertex-sdk@0.14.4':
+    resolution: {integrity: sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g==}
+
   '@asamuzakjp/css-color@4.0.5':
     resolution: {integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==}
 
@@ -146,6 +164,10 @@ packages:
     resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
@@ -1136,6 +1158,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
@@ -1144,6 +1169,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   biome@0.3.3:
     resolution: {integrity: sha512-4LXjrQYbn9iTXu9Y4SKT7ABzTV0WnLDHCVSd2fPUOKsy1gQ+E4xPFmlY1zcWexoi0j7fGHItlL6OWA2CZ/yYAQ==}
@@ -1166,6 +1194,9 @@ packages:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -1426,6 +1457,9 @@ packages:
 
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   editor@1.0.0:
     resolution: {integrity: sha512-SoRmbGStwNYHgKfjOrX2L0mUvp9bUVv0uPppZSOMAntEbcFtoC3MKF5b3T6HQPXKIV+QGY3xPO3JK5it5lVkuw==}
@@ -1783,6 +1817,14 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1855,6 +1897,14 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1864,6 +1914,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
@@ -2086,6 +2140,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -2189,11 +2247,18 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2228,6 +2293,12 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   kaiser@0.0.4:
     resolution: {integrity: sha512-m8ju+rmBqvclZmyrOXgGGhOYSjKJK6RN1NhqEltemY87UqZOxEkizg9TOy1vQSyJ01Wx6SAPuuN0iO2Mgislvw==}
@@ -2480,6 +2551,15 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -3027,9 +3107,15 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
@@ -3147,6 +3233,10 @@ packages:
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
   verror@1.10.0:
     resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
@@ -3228,6 +3318,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.0:
     resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
     engines: {node: '>=20'}
@@ -3235,6 +3328,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -3243,6 +3337,9 @@ packages:
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3340,6 +3437,19 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@anthropic-ai/sdk@0.78.0':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+
+  '@anthropic-ai/vertex-sdk@0.14.4':
+    dependencies:
+      '@anthropic-ai/sdk': 0.78.0
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - zod
+
   '@asamuzakjp/css-color@4.0.5':
     dependencies:
       '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -3374,6 +3484,8 @@ snapshots:
   '@babel/parser@7.28.4':
     dependencies:
       '@babel/types': 7.28.4
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/types@7.28.4':
     dependencies:
@@ -4229,8 +4341,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@7.1.4:
-    optional: true
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -4352,6 +4463,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
@@ -4362,6 +4475,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
     optional: true
+
+  bignumber.js@9.3.1: {}
 
   biome@0.3.3:
     dependencies:
@@ -4396,6 +4511,8 @@ snapshots:
       electron-to-chromium: 1.5.187
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   builtin-modules@3.3.0: {}
 
@@ -4658,6 +4775,10 @@ snapshots:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   editor@1.0.0: {}
 
@@ -5151,6 +5272,26 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
@@ -5250,11 +5391,33 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   har-schema@2.0.0: {}
 
@@ -5316,7 +5479,6 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   husky@9.1.7: {}
 
@@ -5484,6 +5646,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@2.0.1: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -5601,9 +5765,18 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -5638,6 +5811,17 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   kaiser@0.0.4:
     dependencies:
@@ -5858,6 +6042,10 @@ snapshots:
   napi-postinstall@0.3.2: {}
 
   natural-compare@1.4.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.19: {}
 
@@ -6451,10 +6639,14 @@ snapshots:
       tldts: 7.0.16
     optional: true
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@1.4.3(typescript@5.8.3):
     dependencies:
@@ -6605,6 +6797,8 @@ snapshots:
 
   uuid@3.4.0: {}
 
+  uuid@9.0.1: {}
+
   verror@1.10.0:
     dependencies:
       assert-plus: 1.0.0
@@ -6695,6 +6889,8 @@ snapshots:
       xml-name-validator: 5.0.0
     optional: true
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.0:
     optional: true
 
@@ -6711,6 +6907,11 @@ snapshots:
       tr46: 6.0.0
       webidl-conversions: 8.0.0
     optional: true
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/release-notes/generate-release-notes.spec.ts
+++ b/release-notes/generate-release-notes.spec.ts
@@ -96,6 +96,8 @@ describe('run', () => {
       'cli-1111', // port
       '/cli-gen', // endpoint
       true, // useOllama
+      false, // useClaude
+      undefined, // anthropicKey
     );
 
     expect(generateMock).toHaveBeenCalledTimes(1);
@@ -125,6 +127,8 @@ describe('run', () => {
       '45621', // port (default for non-ollama)
       '/v1/chat/completions', // endpoint (default for non-ollama)
       false, // useOllama (default)
+      false, // useClaude (default)
+      undefined, // anthropicKey
     );
     expect(generateMock).toHaveBeenCalled();
   });
@@ -175,7 +179,9 @@ describe('run', () => {
       undefined,
       '45621',
       '/v1/chat/completions',
-      false,
+      false, // useOllama
+      false, // useClaude
+      undefined, // anthropicKey
     );
     expect(generateMock).toHaveBeenCalled();
   });
@@ -193,6 +199,70 @@ describe('run', () => {
     vi.mocked(minimist).mockReturnValue(undefined as unknown as minimist.ParsedArgs);
     await run();
     expect(consoleLogMock).toHaveBeenCalledWith(expect.stringContaining('Parameters:'));
+    expect(ReleaseNotesPreparator).not.toHaveBeenCalled();
+  });
+
+  test('should pass claude options to ReleaseNotesPreparator', async () => {
+    vi.mocked(minimist).mockReturnValue({
+      token: 'my-token',
+      username: 'my-user',
+      milestone: '2.0.0',
+      claude: true,
+      'anthropic-key': 'sk-ant-test-key',
+    } as unknown as minimist.ParsedArgs);
+
+    await run();
+
+    expect(ReleaseNotesPreparator).toHaveBeenCalledWith(
+      'my-token',
+      'podman-desktop',
+      'podman-desktop',
+      '2.0.0',
+      'my-user',
+      undefined,
+      '45621',
+      '/v1/chat/completions',
+      false,
+      true,
+      'sk-ant-test-key',
+    );
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('should fail if --claude is used without API key or Vertex config', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_CODE_USE_VERTEX;
+    delete process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+
+    vi.mocked(minimist).mockReturnValue({
+      claude: true,
+      token: 't',
+      username: 'u',
+      milestone: 'm',
+    } as unknown as minimist.ParsedArgs);
+
+    await run();
+
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      expect.stringContaining('When using --claude, you need to provide an Anthropic API key'),
+    );
+    expect(ReleaseNotesPreparator).not.toHaveBeenCalled();
+  });
+
+  test('should fail if both --ollama and --claude are used', async () => {
+    vi.mocked(minimist).mockReturnValue({
+      ollama: true,
+      claude: true,
+      model: 'some-model',
+      'anthropic-key': 'sk-ant-test',
+      token: 't',
+      username: 'u',
+      milestone: 'm',
+    } as unknown as minimist.ParsedArgs);
+
+    await run();
+
+    expect(consoleLogMock).toHaveBeenCalledWith('Cannot use both --ollama and --claude at the same time');
     expect(ReleaseNotesPreparator).not.toHaveBeenCalled();
   });
 });

--- a/release-notes/generate-release-notes.ts
+++ b/release-notes/generate-release-notes.ts
@@ -31,6 +31,8 @@ interface Config {
   endpoint: string;
   username: string;
   useOllama: boolean;
+  useClaude: boolean;
+  anthropicKey?: string;
 }
 
 export function showHelp(): void {
@@ -43,6 +45,12 @@ export function showHelp(): void {
   console.log('--ollama - script will try to use ollama when model is provided');
   console.log(
     '--model - name of ollama model for generating highlited PRs e.g. gemma3:27b (before running this script run "ollama run gemma3:27b")',
+  );
+  console.log(
+    '--claude - use Claude (Anthropic) API for generating highlighted PRs. Supports direct API (ANTHROPIC_API_KEY) or Vertex AI (ANTHROPIC_VERTEX_PROJECT_ID + CLOUD_ML_REGION)',
+  );
+  console.log(
+    '--anthropic-key - Anthropic API key or export ANTHROPIC_API_KEY env variable (not needed when using Vertex AI)',
   );
   console.log('--port - port on which is service running');
   console.log(
@@ -58,6 +66,8 @@ function parseArguments(parsedArgs: minimist.ParsedArgs): Partial<Config> {
     milestone: '',
     username: process.env.GITHUB_USERNAME,
     useOllama: false,
+    useClaude: false,
+    anthropicKey: process.env.ANTHROPIC_API_KEY,
   };
 
   if (parsedArgs['token']) config.token = parsedArgs.token;
@@ -69,13 +79,27 @@ function parseArguments(parsedArgs: minimist.ParsedArgs): Partial<Config> {
   if (parsedArgs['endpoint']) config.endpoint = parsedArgs.endpoint;
   if (parsedArgs['username']) config.username = parsedArgs.username;
   if (parsedArgs['ollama']) config.useOllama = true;
+  if (parsedArgs['claude']) config.useClaude = true;
+  if (parsedArgs['anthropic-key']) config.anthropicKey = parsedArgs['anthropic-key'];
 
   return config;
 }
 
 function validateConfig(config: Partial<Config>): string | null {
+  if (config.useOllama && config.useClaude) {
+    return 'Cannot use both --ollama and --claude at the same time';
+  }
   if (config.useOllama && !config.model) {
     return 'When using --ollama, you need to specify --model argument';
+  }
+  const vertexRequested = !!process.env.CLAUDE_CODE_USE_VERTEX;
+  const vertexProjectId = !!process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+  if (config.useClaude && vertexRequested && !vertexProjectId) {
+    return 'When using --claude with Vertex AI (enabled via CLAUDE_CODE_USE_VERTEX), you must set ANTHROPIC_VERTEX_PROJECT_ID environment variable';
+  }
+  const useVertex = vertexRequested || vertexProjectId;
+  if (config.useClaude && !config.anthropicKey && !useVertex) {
+    return 'When using --claude, you need to provide an Anthropic API key via --anthropic-key or ANTHROPIC_API_KEY, or enable Vertex AI via CLAUDE_CODE_USE_VERTEX and ANTHROPIC_VERTEX_PROJECT_ID (optionally CLOUD_ML_REGION, which defaults to us-east5)';
   }
   if (!config.token) {
     return 'No token found. Use either GITHUB_TOKEN or pass it as an argument';
@@ -132,6 +156,8 @@ export async function run(): Promise<void> {
     config.port,
     config.endpoint,
     config.useOllama,
+    config.useClaude,
+    config.anthropicKey,
   );
   await releaseNotesPreparator.generate();
 }

--- a/release-notes/release-notes-preparator.spec.ts
+++ b/release-notes/release-notes-preparator.spec.ts
@@ -66,11 +66,26 @@ export class TestReleaseNotesPreparator extends ReleaseNotesPreparator {
     return super.fetchDataFromService(content);
   }
 
+  fetchDataFromClaude(content: string, prompt: string): Promise<HighlightedPR[]> {
+    return super.fetchDataFromClaude(content, prompt);
+  }
+
   includeDataFromIssue(owner: string, repo: string, pr: Issue): Promise<Issue> {
     return super.includeDataFromIssue(owner, repo, pr);
   }
 }
 
+const mockClaudeCreate = vi.fn();
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: { create: mockClaudeCreate },
+  })),
+}));
+vi.mock('@anthropic-ai/vertex-sdk', () => ({
+  AnthropicVertex: vi.fn().mockImplementation(() => ({
+    messages: { create: mockClaudeCreate },
+  })),
+}));
 vi.mock('@octokit/rest');
 vi.mock('mustache');
 vi.mock('fs', async () => {
@@ -315,6 +330,80 @@ describe('ReleaseNotesPreparator', () => {
     test('should return empty array on HTTP error', async () => {
       fetchMock.mockResolvedValue({ ok: false, status: 500 });
       expect(await preparator.fetchDataFromService(content)).toEqual([]);
+    });
+  });
+
+  describe('fetchDataFromClaude', () => {
+    let claudePreparator: TestReleaseNotesPreparator;
+    const hlPRs = [{ title: 'HL1', shortDesc: 's', longDesc: 'l' }];
+
+    beforeEach(() => {
+      claudePreparator = new TestReleaseNotesPreparator(
+        mockToken,
+        mockOrg,
+        mockRepo,
+        mockMilestoneName,
+        mockUsername,
+        mockModel,
+        mockPort,
+        mockEndpoint,
+        false,
+        true,
+        'sk-ant-test-key',
+      );
+    });
+
+    test('should parse highlighted PRs from Claude response', async () => {
+      mockClaudeCreate.mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify({ prs: hlPRs }) }],
+      });
+      const result = await claudePreparator.fetchDataFromClaude('PR content', 'prompt');
+      expect(result).toEqual(hlPRs);
+    });
+
+    test('should return empty array when Claude returns no text block', async () => {
+      mockClaudeCreate.mockResolvedValue({
+        content: [{ type: 'image', source: {} }],
+      });
+      const result = await claudePreparator.fetchDataFromClaude('PR content', 'prompt');
+      expect(result).toEqual([]);
+    });
+
+    test('should return empty array when Claude response has no JSON', async () => {
+      mockClaudeCreate.mockResolvedValue({
+        content: [{ type: 'text', text: 'no json here' }],
+      });
+      const result = await claudePreparator.fetchDataFromClaude('PR content', 'prompt');
+      expect(result).toEqual([]);
+    });
+
+    test('should return empty array on API error', async () => {
+      mockClaudeCreate.mockRejectedValue(new Error('API error'));
+      const result = await claudePreparator.fetchDataFromClaude('PR content', 'prompt');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchDataFromService with Claude', () => {
+    test('should delegate to fetchDataFromClaude when useClaude is true', async () => {
+      const claudePreparator = new TestReleaseNotesPreparator(
+        mockToken,
+        mockOrg,
+        mockRepo,
+        mockMilestoneName,
+        mockUsername,
+        mockModel,
+        mockPort,
+        mockEndpoint,
+        false,
+        true,
+        'sk-ant-test-key',
+      );
+      const hlPRs = [{ title: 'HL1', shortDesc: 's', longDesc: 'l' }];
+      vi.spyOn(claudePreparator, 'fetchDataFromClaude').mockResolvedValue(hlPRs);
+      const result = await claudePreparator.fetchDataFromService('content');
+      expect(result).toEqual(hlPRs);
+      expect(claudePreparator.fetchDataFromClaude).toHaveBeenCalled();
     });
   });
 

--- a/release-notes/release-notes-preparator.ts
+++ b/release-notes/release-notes-preparator.ts
@@ -19,6 +19,8 @@
 
 import * as fs from 'node:fs';
 
+import Anthropic from '@anthropic-ai/sdk';
+import { AnthropicVertex } from '@anthropic-ai/vertex-sdk';
 import type { components } from '@octokit/openapi-types';
 import { Octokit } from '@octokit/rest';
 import mustache from 'mustache';
@@ -66,6 +68,8 @@ export class ReleaseNotesPreparator {
     private port: string,
     private endpoint: string,
     private useOllama: boolean,
+    private useClaude: boolean = false,
+    private anthropicKey: string = '',
   ) {
     this.octokit = new Octokit({ auth: token });
   }
@@ -224,6 +228,62 @@ export class ReleaseNotesPreparator {
     return prs;
   }
 
+  protected async fetchDataFromClaude(_content: string, prompt: string): Promise<HighlightedPR[]> {
+    const vertexProjectId = process.env.ANTHROPIC_VERTEX_PROJECT_ID;
+    if (process.env.CLAUDE_CODE_USE_VERTEX && !vertexProjectId) {
+      throw new Error(
+        'CLAUDE_CODE_USE_VERTEX is set but ANTHROPIC_VERTEX_PROJECT_ID is not defined. ' +
+          'Please set ANTHROPIC_VERTEX_PROJECT_ID to a valid Vertex AI project ID or unset CLAUDE_CODE_USE_VERTEX.',
+      );
+    }
+    const useVertex = !!process.env.CLAUDE_CODE_USE_VERTEX || !!vertexProjectId;
+
+    const client = useVertex
+      ? new AnthropicVertex({
+          projectId: vertexProjectId,
+          region: process.env.CLOUD_ML_REGION ?? 'us-east5',
+        })
+      : new Anthropic({ apiKey: this.anthropicKey });
+
+    const defaultModel = useVertex ? 'claude-sonnet-4@20250514' : 'claude-sonnet-4-20250514';
+
+    try {
+      const message = await client.messages.create({
+        model: this.model ?? defaultModel,
+        max_tokens: 4096,
+        system:
+          'You are a helpful assistant that returns only JSON containing exactly a property "prs", which is an array of objects described in the prompt. In the response, don\'t address the content as "This PR" etc.; address it as if it is a feature or fix.',
+        messages: [
+          {
+            role: 'user',
+            content: prompt,
+          },
+        ],
+      });
+
+      const textBlock = message.content.find(block => block.type === 'text');
+      if (!textBlock || textBlock.type !== 'text') {
+        console.error('No text response from Claude');
+        return [];
+      }
+
+      const jsonStart = textBlock.text.indexOf('{');
+      const jsonEnd = textBlock.text.lastIndexOf('}');
+      const jsonMatch = jsonStart !== -1 && jsonEnd > jsonStart ? [textBlock.text.slice(jsonStart, jsonEnd + 1)] : null;
+      if (!jsonMatch) {
+        console.error('Could not extract JSON from Claude response');
+        return [];
+      }
+
+      return JSON.parse(jsonMatch[0]).prs as HighlightedPR[];
+    } catch (e: unknown) {
+      console.error(
+        `Got error ${e}.\nThere was a problem when generating highlighted PRs with Claude. Generating release notes without highlights.`,
+      );
+      return [];
+    }
+  }
+
   protected async fetchDataFromService(content: string): Promise<HighlightedPR[]> {
     const schema = {
       type: 'object',
@@ -293,6 +353,10 @@ Here are a few examples of the expected output format:
 DATA:
 ${content}
 `;
+    if (this.useClaude) {
+      return this.fetchDataFromClaude(content, prompt);
+    }
+
     let body;
     if (this.useOllama) {
       body = {


### PR DESCRIPTION
this adds both coporate support for red hat via vertex api and the standard anthropic key api. Added documentation and tests

Assisted-by: Claude opus 4.6

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Please setup claude the red hat corporate way by following
directions that was emailed to you

make sure claude cli works on your computer

then do "pnpm generate --claude --username foo --milestone 1.26.0"

With the latest milestone 

it should work

btw make sure you have your git token ready on hand if not create one and add it 

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
