### PR TITLE
fix: resolve CVE-2019-10744 in lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
   },
   "pnpm": {
     "overrides": {
-      "form-data@<2.5.4": "2.5.4"
+      "form-data@<2.5.4": "2.5.4",
+      "lodash@<4.17.12": "4.18.1"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   form-data@<2.5.4: 2.5.4
+  lodash@<4.17.12: 4.18.1
 
 importers:
 
@@ -2447,11 +2448,8 @@ packages:
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
-  lodash@3.10.1:
-    resolution: {integrity: sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -4731,7 +4729,7 @@ snapshots:
     dependencies:
       core-js: 2.6.12
       kaiser: 0.0.4
-      lodash: 4.17.21
+      lodash: 4.18.1
       regenerator-runtime: 0.9.6
 
   ecc-jsbn@0.1.2:
@@ -5489,7 +5487,7 @@ snapshots:
       cli-cursor: 1.0.2
       cli-width: 1.1.1
       figures: 1.7.0
-      lodash: 3.10.1
+      lodash: 4.18.1
       readline2: 1.0.1
       run-async: 0.1.0
       rx-lite: 3.1.2
@@ -5858,9 +5856,7 @@ snapshots:
 
   lodash.upperfirst@4.3.1: {}
 
-  lodash@3.10.1: {}
-
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -6155,7 +6151,7 @@ snapshots:
   request-promise@3.0.0:
     dependencies:
       bluebird: 3.7.2
-      lodash: 4.17.21
+      lodash: 4.18.1
       request: 2.88.2
 
   request@2.88.2:


### PR DESCRIPTION
### What does this PR do?

Fix critical severity vulnerability CVE-2019-10744 in `lodash`.

**Advisory**: Prototype Pollution in lodash
**Vulnerable versions**: <4.17.12
**Patched versions**: >=4.17.12
**Advisory URL**: https://github.com/advisories/GHSA-jf85-cpcp-j695

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2019-10744: _Prototype Pollution in lodash_

### How to test this PR?

Run `pnpm audit` and verify CVE-2019-10744 is no longer reported